### PR TITLE
Make dependencies libthai, cairo and xft optional via meson options

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -56,10 +56,10 @@ class PangoConan(ConanFile):
     def _configure_meson(self):
         defs = dict()
         defs["introspection"] = "false"
-       	defs["libthai"] = "enabled" if self.options.libthai else "disabled"
-       	defs["cairo"] = "enabled" if self.options.cairo else "disabled"
-       	defs["xft"] = "enabled" if self.options.xft else "disabled"
-	        
+        defs["libthai"] = "enabled" if self.options.libthai else "disabled"
+        defs["cairo"] = "enabled" if self.options.cairo else "disabled"
+        defs["xft"] = "enabled" if self.options.xft else "disabled"
+        
         meson = Meson(self)
         meson.configure(build_folder="build", source_folder=self._source_subfolder, defs=defs, args=['--wrap-mode=nofallback'])
         return meson

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,7 @@ class PangoConan(ConanFile):
         if self.options.freetype:
             self.requires("freetype/2.10.2")
         if self.options.fontconfig:
-            self.requires("fontconfig/2.13.92@produkte+apps+devices+conan+conan-center-index/wo")
+            self.requires("fontconfig/2.13.92")
         if self.options.cairo:
             self.requires("cairo/1.17.2@bincrafters/stable")
         self.requires("harfbuzz/2.6.8")

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,8 +15,8 @@ class PangoConan(ConanFile):
     author = "Bincrafters"
     topics = ("conan", "fontconfig", "fonts", "freedesktop")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": True, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "libthai": [True, False], "cairo": [True, False], "xft": [True, False]}
+    default_options = {"shared": True, "fPIC": True, "libthai": False, "cairo": True, "xft": True}
     generators = "pkg_config"
     exports = "LICENSE"
     exports_sources = ["patches/*.patch"]
@@ -40,7 +40,8 @@ class PangoConan(ConanFile):
         self.requires("freetype/2.10.2")
         if self.settings.os != "Windows":
             self.requires("fontconfig/2.13.91")
-        self.requires("cairo/1.17.2@bincrafters/stable")
+        if self.options.cairo:
+        	self.requires("cairo/1.17.2@bincrafters/stable")
         self.requires("harfbuzz/2.6.8")
         self.requires("glib/2.65.1")
         self.requires("fribidi/1.0.9")
@@ -55,6 +56,10 @@ class PangoConan(ConanFile):
     def _configure_meson(self):
         defs = dict()
         defs["introspection"] = "false"
+       	defs["libthai"] = "enabled" if self.options.libthai else "disabled"
+       	defs["cairo"] = "enabled" if self.options.cairo else "disabled"
+       	defs["xft"] = "enabled" if self.options.xft else "disabled"
+	        
         meson = Meson(self)
         meson.configure(build_folder="build", source_folder=self._source_subfolder, defs=defs, args=['--wrap-mode=nofallback'])
         return meson

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,8 +15,8 @@ class PangoConan(ConanFile):
     author = "Bincrafters"
     topics = ("conan", "fontconfig", "fonts", "freedesktop")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False], "libthai": [True, False], "cairo": [True, False], "xft": [True, False, "auto"]}
-    default_options = {"shared": True, "fPIC": True, "libthai": False, "cairo": True, "xft": "auto"}
+    options = {"shared": [True, False], "fPIC": [True, False], "libthai": [True, False], "cairo": [True, False], "xft": [True, False, "auto"], "freetype": [True, False], "fontconfig": [True, False, "auto"]}
+    default_options = {"shared": True, "fPIC": True, "libthai": False, "cairo": True, "xft": "auto", "freetype": True, "fontconfig": "auto"}
     generators = "pkg_config"
     exports = "LICENSE"
     exports_sources = ["patches/*.patch"]
@@ -37,11 +37,12 @@ class PangoConan(ConanFile):
         self.build_requires("meson/0.54.2")
 
     def requirements(self):
-        self.requires("freetype/2.10.2")
-        if self.settings.os != "Windows":
-            self.requires("fontconfig/2.13.91")
+        if self.options.freetype:
+            self.requires("freetype/2.10.2")
+        if self.options.fontconfig:
+            self.requires("fontconfig/2.13.92@produkte+apps+devices+conan+conan-center-index/wo")
         if self.options.cairo:
-        	self.requires("cairo/1.17.2@bincrafters/stable")
+            self.requires("cairo/1.17.2@bincrafters/stable")
         self.requires("harfbuzz/2.6.8")
         self.requires("glib/2.65.1")
         self.requires("fribidi/1.0.9")
@@ -56,6 +57,8 @@ class PangoConan(ConanFile):
     def configure(self):
         if(self.options.xft == "auto"):
             self.options.xft = (self.settings.os == 'Linux' or self.settings.os == 'FreeBSD')
+        if(self.options.fontconfig == "auto"):
+            self.options.fontconfig = (self.settings.os != 'Windows' and self.settings.os == 'Macos')
 
     def _configure_meson(self):
         defs = dict()
@@ -63,6 +66,8 @@ class PangoConan(ConanFile):
         defs["libthai"] = "enabled" if self.options.libthai else "disabled"
         defs["cairo"] = "enabled" if self.options.cairo else "disabled"
         defs["xft"] = "enabled" if self.options.xft else "disabled"
+        defs["fontconfig"] = "enabled" if self.options.fontconfig else "disabled"
+        defs["freetype"] = "enabled" if self.options.freetype else "disabled"
         
         meson = Meson(self)
         meson.configure(build_folder="build", source_folder=self._source_subfolder, defs=defs, args=['--wrap-mode=nofallback'])

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,8 +15,8 @@ class PangoConan(ConanFile):
     author = "Bincrafters"
     topics = ("conan", "fontconfig", "fonts", "freedesktop")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False], "libthai": [True, False], "cairo": [True, False], "xft": [True, False]}
-    default_options = {"shared": True, "fPIC": True, "libthai": False, "cairo": True, "xft": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "libthai": [True, False], "cairo": [True, False], "xft": [True, False, "auto"]}
+    default_options = {"shared": True, "fPIC": True, "libthai": False, "cairo": True, "xft": "auto"}
     generators = "pkg_config"
     exports = "LICENSE"
     exports_sources = ["patches/*.patch"]
@@ -52,6 +52,10 @@ class PangoConan(ConanFile):
         tools.get(source_url.format(self.version), sha256=sha256)
         extrated_dir = self.name + "-" + self.version
         os.rename(extrated_dir, self._source_subfolder)
+
+    def configure(self):
+        if(self.options.xft == "auto"):
+            self.options.xft = (self.settings.os == 'Linux' or self.settings.os == 'FreeBSD')
 
     def _configure_meson(self):
         defs = dict()

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,7 +58,7 @@ class PangoConan(ConanFile):
         if(self.options.xft == "auto"):
             self.options.xft = (self.settings.os == 'Linux' or self.settings.os == 'FreeBSD')
         if(self.options.fontconfig == "auto"):
-            self.options.fontconfig = (self.settings.os != 'Windows' and self.settings.os == 'Macos')
+            self.options.fontconfig = (self.settings.os != 'Windows' and self.settings.os != 'Macos')
 
     def _configure_meson(self):
         defs = dict()

--- a/patches/optdeps.patch
+++ b/patches/optdeps.patch
@@ -1,5 +1,5 @@
 diff --git a/meson.build b/meson.build
-index 160a9152..20f73947 100644
+index 9708f826..ca160f4f 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -216,7 +216,7 @@ fribidi_dep = dependency('fribidi', version: fribidi_req_version,
@@ -11,7 +11,62 @@ index 160a9152..20f73947 100644
  if thai_dep.found()
    pango_conf.set('HAVE_LIBTHAI', 1)
    pango_deps += thai_dep
-@@ -341,7 +341,7 @@ if build_pangoft2
+@@ -270,16 +270,24 @@ endif
+ pango_deps += harfbuzz_dep
+ 
+ # Only use FontConfig fallback when required or requested
+-fontconfig_required = (host_system != 'windows' and host_system != 'darwin') or get_option('use_fontconfig')
+ 
+-fontconfig_dep = dependency('fontconfig', version: fontconfig_req_version, required: false)
++fontconfig_option = get_option('fontconfig')
++
++fontconfig_sys_required = (host_system != 'windows' and host_system != 'darwin')
++if fontconfig_sys_required and fontconfig_option.disabled()
++  error('Fontconfig is required on this platform (pass -Dfontconfig=enabled or -Dfontconfig=auto)')
++endif
++
++fontconfig_required = fontconfig_sys_required or fontconfig_option.enabled()
++
++fontconfig_dep = dependency('fontconfig', version: fontconfig_req_version, required: fontconfig_option)
+ if fontconfig_dep.found()
+   fontconfig_pc = 'fontconfig'
+ else
+   if cc.get_id() == 'msvc' and cc.has_header('fontconfig/fontconfig.h')
+     # Look for the Visual Studio-style import library if FontConfig's .pc file cannot be
+     # found on Visual Studio
+-    fontconfig_dep = cc.find_library('fontconfig', required: false)
++    fontconfig_dep = cc.find_library('fontconfig', required: fontconfig_option)
+     if fontconfig_dep.found()
+       fontconfig_lib = '-lfontconfig'
+     endif
+@@ -312,7 +320,7 @@ message('fontconfig has FcWeightFromOpenTypeDouble: ' + res)
+ 
+ # The first version of freetype with a pkg-config file is 2.1.5
+ # We require both fontconfig and freetype if we are to have either.
+-freetype_dep = dependency('freetype2', required: false)
++freetype_dep = dependency('freetype2', required: get_option('freetype'))
+ 
+ if freetype_dep.found()
+   freetype2_pc = 'freetype2'
+@@ -320,7 +328,7 @@ else
+   if cc.get_id() == 'msvc' and cc.has_header('ft2build.h')
+     foreach ft2_lib: ['freetype', 'freetypemt']
+       if not freetype_dep.found()
+-        freetype_dep = cc.find_library(ft2_lib, required: false)
++        freetype_dep = cc.find_library(ft2_lib, required: get_option('freetype'))
+         if freetype_dep.found()
+           freetype2_lib = '-l@0@'.format(ft2_lib)
+         endif
+@@ -330,7 +338,7 @@ else
+ endif
+ 
+ if fontconfig_required and not freetype_dep.found()
+-  freetype_dep = dependency('freetype2', required: false,
++  freetype_dep = dependency('freetype2', required: get_option('freetype'),
+                             fallback: ['freetype2', 'freetype_dep'])
+ endif
+ 
+@@ -341,7 +349,7 @@ if build_pangoft2
    pango_deps += freetype_dep
  endif
  
@@ -20,7 +75,7 @@ index 160a9152..20f73947 100644
  if xft_dep.found() and fontconfig_dep.found() and freetype_dep.found()
    pango_conf.set('HAVE_XFT', 1)
    pango_deps += dependency('xrender', required: false)
-@@ -364,7 +364,7 @@ if host_system == 'darwin'
+@@ -364,7 +372,7 @@ if host_system == 'darwin'
  endif
  
  cairo_found_type = ''
@@ -29,7 +84,7 @@ index 160a9152..20f73947 100644
  
  if cairo_dep.found()
    cairo_found_type = cairo_dep.type_name()
-@@ -379,7 +379,7 @@ endif
+@@ -379,7 +387,7 @@ endif
  # in a declarative way
  if not cairo_dep.found()
    cairo_dep = dependency('cairo', version: cairo_req_version,
@@ -39,10 +94,22 @@ index 160a9152..20f73947 100644
  endif
  
 diff --git a/meson_options.txt b/meson_options.txt
-index b0395b5e..437ba149 100644
+index b0395b5e..5aa7c795 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -18,3 +18,15 @@ option('sysprof',
+@@ -10,11 +10,27 @@ option('install-tests',
+        description : 'Install tests',
+        type: 'boolean',
+        value: 'false')
+-option('use_fontconfig',
+-       description : 'Force using FontConfig where it is optional, on Windows and macOS.  This is ignored on platforms where it is required',
+-       type: 'boolean',
+-       value: 'false')
++option('fontconfig',
++       description : 'Build with FontConfig support. Passing \'auto\' or \'disabled\' disables fontconfig where it is optional, i.e. on Windows and macOS. Passing \'disabled\' on platforms where fontconfig is required results in error.',
++       type: 'feature',
++       value: 'auto')
+ option('sysprof',
         type : 'feature',
         value : 'disabled',
         description : 'include tracing support for sysprof')
@@ -58,6 +125,10 @@ index b0395b5e..437ba149 100644
 +       type : 'feature',
 +       value : 'auto',
 +       description : 'Build with xft support')
++option('freetype',
++       type : 'feature',
++       value : 'auto',
++       description : 'Build with freetype support')
 diff --git a/tests/meson.build b/tests/meson.build
 index 234fbf63..6e10e2b7 100644
 --- a/tests/meson.build

--- a/patches/optdeps.patch
+++ b/patches/optdeps.patch
@@ -1,0 +1,88 @@
+diff --git a/meson.build b/meson.build
+index 160a9152..20f73947 100644
+--- a/meson.build
++++ b/meson.build
+@@ -216,7 +216,7 @@ fribidi_dep = dependency('fribidi', version: fribidi_req_version,
+                          default_options: ['docs=false'])
+ pango_deps += fribidi_dep
+ 
+-thai_dep = dependency('libthai', version: libthai_req_version, required: false)
++thai_dep = dependency('libthai', version: libthai_req_version, required: get_option('libthai'))
+ if thai_dep.found()
+   pango_conf.set('HAVE_LIBTHAI', 1)
+   pango_deps += thai_dep
+@@ -341,7 +341,7 @@ if build_pangoft2
+   pango_deps += freetype_dep
+ endif
+ 
+-xft_dep = dependency('xft', version: xft_req_version, required: false)
++xft_dep = dependency('xft', version: xft_req_version, required: get_option('xft'))
+ if xft_dep.found() and fontconfig_dep.found() and freetype_dep.found()
+   pango_conf.set('HAVE_XFT', 1)
+   pango_deps += dependency('xrender', required: false)
+@@ -364,7 +364,7 @@ if host_system == 'darwin'
+ endif
+ 
+ cairo_found_type = ''
+-cairo_dep = dependency('cairo', version: cairo_req_version, required: false)
++cairo_dep = dependency('cairo', version: cairo_req_version, required: get_option('cairo'))
+ 
+ if cairo_dep.found()
+   cairo_found_type = cairo_dep.type_name()
+@@ -379,7 +379,7 @@ endif
+ # in a declarative way
+ if not cairo_dep.found()
+   cairo_dep = dependency('cairo', version: cairo_req_version,
+-                         fallback: ['cairo', 'libcairo_dep'])
++                         fallback: ['cairo', 'libcairo_dep'], required: get_option('cairo'))
+   cairo_found_type = cairo_dep.type_name()
+ endif
+ 
+diff --git a/meson_options.txt b/meson_options.txt
+index b0395b5e..437ba149 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -18,3 +18,15 @@ option('sysprof',
+        type : 'feature',
+        value : 'disabled',
+        description : 'include tracing support for sysprof')
++option('libthai',
++       type : 'feature',
++       value : 'auto',
++       description : 'Build with libthai support')
++option('cairo',
++       type : 'feature',
++       value : 'auto',
++       description : 'Build with cairo support')
++option('xft',
++       type : 'feature',
++       value : 'auto',
++       description : 'Build with xft support')
+diff --git a/tests/meson.build b/tests/meson.build
+index 234fbf63..6e10e2b7 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -20,11 +20,7 @@ tests = [
+   [ 'testboundaries' ],
+   [ 'testboundaries_ucd' ],
+   [ 'testcolor' ],
+-  [ 'testmisc', [ 'testmisc.c' ], [ libpangocairo_dep ] ],
+-  [ 'testscript' ],
+-  [ 'test-harfbuzz', [ 'test-harfbuzz.c' ], [ libpangocairo_dep ] ],
+-  [ 'cxx-test', [ 'cxx-test.cpp' ], [ libpangocairo_dep ] ],
+-  [ 'test-break', [ 'test-break.c', 'test-common.c' ], [libpangocairo_dep ] ],
++  [ 'testscript' ]
+ ]
+ 
+ if build_pangoft2
+@@ -45,6 +41,10 @@ if cairo_dep.found()
+     [ 'test-shape', [ 'test-shape.c', 'test-common.c' ], [ libpangocairo_dep ] ],
+     [ 'test-font', [ 'test-font.c' ], [ libpangocairo_dep ] ],
+     [ 'testattributes', [ 'testattributes.c', 'test-common.c' ], [ libpangocairo_dep ] ],
++    [ 'testmisc', [ 'testmisc.c' ], [ libpangocairo_dep, glib_dep, harfbuzz_dep ] ],
++    [ 'cxx-test', [ 'cxx-test.cpp' ], [ libpangocairo_dep, gobject_dep, harfbuzz_dep ] ],
++    [ 'test-harfbuzz', [ 'test-harfbuzz.c' ], [ libpangocairo_dep, gobject_dep, harfbuzz_dep ] ],
++    [ 'test-break', [ 'test-break.c', 'test-common.c' ], [libpangocairo_dep, glib_dep, harfbuzz_dep ] ]
+   ]
+ 
+   if pango_cairo_backends.contains('png')


### PR DESCRIPTION
This PR patches pango and adds options to make the dependencies to libthai, cairo and xft optional. Until now, pango's build system automatically detects libthai and Xft as installed on the system, which yields unreliable build results. If cairo is not actually needed, it's desirable to disable it.

When pango accepts [the PR](https://gitlab.gnome.org/GNOME/pango/-/merge_requests/235) to its build system, the patch in conan-pango can be removed.